### PR TITLE
Cross platform support

### DIFF
--- a/mc_server_manager/server_manager.py
+++ b/mc_server_manager/server_manager.py
@@ -339,12 +339,13 @@ class JavaServerManager:
             timeout_time = time.time() + 10
             processes = self.get_processes()
             while processes:
+                if time.time() > timeout_time:
+                    self.force_stop()
+
                 for process in processes:
                     if not process.is_running():
                         processes.remove(process)
                         continue
-                    if time.time() > timeout_time:
-                        process.terminate()
         
         if yield_until_closed:
             force_close()

--- a/mc_server_manager/server_manager.py
+++ b/mc_server_manager/server_manager.py
@@ -86,6 +86,9 @@ class JavaServerManager:
         start_script_path: Path,
         **kwargs
     ):
+        if isinstance(working_directory, str):
+            working_directory = Path(working_directory)
+
         props_path = working_directory / "server.properties"
         if not props_path.exists():
             raise FileNotFoundError(f"No server.properties found in {working_directory}")

--- a/mc_server_manager/server_manager.py
+++ b/mc_server_manager/server_manager.py
@@ -213,12 +213,12 @@ class JavaServerManager:
             subprocess.Popen(
                 ["cmd", "/c", str(self.start_script)],
                 creationflags=subprocess.CREATE_NEW_CONSOLE,
-                cwd=self.working_directory
+                cwd=str(self.working_directory)
             )
         else:
             subprocess.Popen(
-                ["java", "-jar", str(self.start_script)],
-                cwd=self.working_directory
+                ["bash", str(self.start_script)],
+                cwd=str(self.working_directory)
             )
 
         return True, "Server started."

--- a/mc_server_manager/server_manager.py
+++ b/mc_server_manager/server_manager.py
@@ -44,14 +44,11 @@ class JavaServerManager:
         if isinstance(start_script_path, str):
             start_script_path = Path(start_script_path)
 
-        if not working_directory.exists():
-            raise FileNotFoundError('Working directory path does not exist.')
-        
-        if not start_script_path.exists():
-            raise FileNotFoundError('Server start script path does not exist.')
+        if not start_script_path.is_file():
+            raise FileNotFoundError("Working directory path is not a directory.")
         
         if not working_directory.is_dir():
-            raise ValueError("Working directory path is not a directory.")
+            raise FileNotFoundError("Working directory path is not a directory.")
 
         # JavaServer does some address checks internally to verify validity, so it is run first.
         self.server = JavaServer(server_ip, port=server_port, timeout=connection_timeout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mc-server-manager"
-version = "1.0.1"
+version = "1.1.0"
 description = "A python minecraft server manager"
 authors = [{ name = "Yousef AlShaikh", email = "yousefalshaikh17@gmail.com" }]
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mc-server-manager"
-version = "1.0.0"
+version = "1.0.1"
 description = "A python minecraft server manager"
 authors = [{ name = "Yousef AlShaikh", email = "yousefalshaikh17@gmail.com" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Added Linux & MacOS compatbility along with improvements to the class.

- Changed working_directory and start_script_path from str to pathlib.Path objects. str is still supported as a parameter and will be converted in the constructor.
- Comparisons in get_processes() are more accurate due to the usage of Path objects now. Path also accounts for different platform difference.
- Adjusted force stop timer to use in-class force_close() function instead of process.terminate().
- Start logic now supports multiple platforms. It also supports running .jar files.